### PR TITLE
Add packaging metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Environment files
+.env
+
+# Task data file
+tasks.json
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,40 @@ This is a new Git repository created with Claude Code.
 
 This repository is set up and ready for development.
 
+## Requirements
+
+* Python 3.8+
+
+No external dependencies are required.
+
 ## Features
 
 - Git repository with GitHub integration
 - Ready for VS Code development
 - Claude Code compatible
+
+## CLI Task Manager
+
+The repository includes an enhanced CLI tool for managing tasks. Tasks are saved
+in a `tasks.json` file located next to the script.
+
+### Usage
+
+```bash
+# Add a task
+python task_manager.py add "Buy milk"
+
+# Add a task with a due date and priority
+python task_manager.py add "Submit report" --due-date 2024-05-01 --priority high
+
+# List tasks
+python task_manager.py list
+
+# Complete a task by its ID
+python task_manager.py complete 1
+
+# Delete a task
+python task_manager.py delete 1
+```
+
+See `LICENSE` for licensing information.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,42 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "cli-task-manager"
+version = "0.1.0"
+description = "A command-line task manager with priorities and due dates"
+readme = "README.md"
+requires-python = ">=3.8"
+license = "MIT"
+authors = [
+    { name = "Your Name", email = "your.email@example.com" }
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: End Users/Desktop",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Topic :: Office/Business",
+]
+
+[project.scripts]
+task-manager = "task_manager:main"
+
+[tool.ruff]
+line-length = 88
+target-version = "py38"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "N", "W"]
+ignore = []
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+line-ending = "auto"

--- a/task_manager.py
+++ b/task_manager.py
@@ -1,0 +1,155 @@
+import argparse
+import json
+import os
+from datetime import datetime
+from typing import List, Dict, Any
+
+TASKS_FILE = os.path.join(os.path.dirname(__file__), 'tasks.json')
+PRIORITIES = ['low', 'medium', 'high']
+
+
+def load_tasks() -> List[Dict[str, Any]]:
+    if not os.path.exists(TASKS_FILE):
+        return []
+    try:
+        with open(TASKS_FILE, 'r') as f:
+            return json.load(f)
+    except (json.JSONDecodeError, FileNotFoundError):
+        return []
+
+
+def save_tasks(tasks: List[Dict[str, Any]]) -> None:
+    with open(TASKS_FILE, 'w') as f:
+        json.dump(tasks, f, indent=2)
+
+
+def add_task(
+    description: str,
+    due_date: str | None = None,
+    priority: str = 'medium'
+) -> None:
+    if priority not in PRIORITIES:
+        raise ValueError(f"Priority must be one of: {', '.join(PRIORITIES)}")
+
+    if due_date:
+        try:
+            datetime.strptime(due_date, '%Y-%m-%d')
+        except ValueError:
+            raise ValueError('Due date must be in YYYY-MM-DD format')
+
+    tasks = load_tasks()
+    task = {
+        'description': description,
+        'completed': False,
+        'priority': priority,
+        'due_date': due_date,
+        'created_at': datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+    }
+    tasks.append(task)
+    save_tasks(tasks)
+    print(f"Added task: {description}")
+
+
+def list_tasks(show_completed: bool = True) -> None:
+    tasks = load_tasks()
+    if not tasks:
+        print('No tasks found.')
+        return
+
+    visible_tasks = [
+        t for t in tasks if show_completed or not t.get('completed')
+    ]
+    if not visible_tasks:
+        print('No tasks to display.')
+        return
+
+    visible_tasks.sort(
+        key=lambda x: (
+            PRIORITIES.index(x.get('priority', 'medium')),
+            x.get('due_date', '9999-99-99')
+        )
+    )
+
+    for i, task in enumerate(visible_tasks, 1):
+        status = '✓' if task.get('completed') else ' '
+        priority = f"[{task.get('priority', 'medium')}]"
+        due_date = (
+            f"Due: {task.get('due_date')}" if task.get('due_date') else ''
+        )
+        print(
+            f"{i}. [{status}] {priority} {task.get('description')} {due_date}"
+        )
+
+
+def complete_task(task_id: int) -> None:
+    tasks = load_tasks()
+    index = task_id - 1
+    if index < 0 or index >= len(tasks):
+        print('Invalid task ID')
+        return
+    tasks[index]['completed'] = True
+    tasks[index]['completed_at'] = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+    save_tasks(tasks)
+    print(f"Completed task {task_id}")
+
+
+def delete_task(task_id: int) -> None:
+    tasks = load_tasks()
+    index = task_id - 1
+    if index < 0 or index >= len(tasks):
+        print('Invalid task ID')
+        return
+    deleted_task = tasks.pop(index)
+    save_tasks(tasks)
+    print(f"Deleted task: {deleted_task['description']}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description='Enhanced CLI task manager')
+    subparsers = parser.add_subparsers(dest='command', required=True)
+
+    add_parser = subparsers.add_parser('add', help='Add a new task')
+    add_parser.add_argument('description', help='Task description')
+    add_parser.add_argument('--due-date', help='Due date (YYYY-MM-DD)')
+    add_parser.add_argument(
+        '--priority',
+        choices=PRIORITIES,
+        default='medium',
+        help='Task priority (default: medium)'
+    )
+
+    list_parser = subparsers.add_parser('list', help='List tasks')
+    list_parser.add_argument(
+        '--hide-completed',
+        action='store_true',
+        help='Hide completed tasks'
+    )
+
+    complete_parser = subparsers.add_parser(
+        'complete',
+        help='Mark a task as completed'
+    )
+    complete_parser.add_argument('id', type=int, help='ID of task to complete')
+
+    delete_parser = subparsers.add_parser('delete', help='Delete a task')
+    delete_parser.add_argument('id', type=int, help='ID of task to delete')
+
+    args = parser.parse_args()
+
+    try:
+        if args.command == 'add':
+            add_task(args.description, args.due_date, args.priority)
+        elif args.command == 'list':
+            list_tasks(not args.hide_completed)
+        elif args.command == 'complete':
+            complete_task(args.id)
+        elif args.command == 'delete':
+            delete_task(args.id)
+    except ValueError as e:
+        print(f'Error: {e}')
+        return 1
+    return 0
+
+
+if __name__ == '__main__':
+    exit(main())

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -1,0 +1,55 @@
+import os
+import tempfile
+import json
+from contextlib import redirect_stdout
+from io import StringIO
+
+import unittest
+
+import task_manager
+
+
+class TaskManagerTest(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.tasks_file = os.path.join(self.tmpdir.name, 'tasks.json')
+        # patch TASKS_FILE
+        self._orig_tasks_file = task_manager.TASKS_FILE
+        task_manager.TASKS_FILE = self.tasks_file
+
+    def tearDown(self):
+        task_manager.TASKS_FILE = self._orig_tasks_file
+        self.tmpdir.cleanup()
+
+    def read_tasks(self):
+        if not os.path.exists(self.tasks_file):
+            return []
+        with open(self.tasks_file) as f:
+            return json.load(f)
+
+    def test_add_and_list(self):
+        task_manager.add_task('Test task', priority='high')
+        tasks = self.read_tasks()
+        self.assertEqual(len(tasks), 1)
+        self.assertEqual(tasks[0]['description'], 'Test task')
+        self.assertEqual(tasks[0]['priority'], 'high')
+
+        buf = StringIO()
+        with redirect_stdout(buf):
+            task_manager.list_tasks()
+        output = buf.getvalue()
+        self.assertIn('Test task', output)
+
+    def test_complete_and_delete(self):
+        task_manager.add_task('Another task')
+        task_manager.complete_task(1)
+        tasks = self.read_tasks()
+        self.assertTrue(tasks[0]['completed'])
+
+        task_manager.delete_task(1)
+        tasks = self.read_tasks()
+        self.assertEqual(tasks, [])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `pyproject.toml` to configure packaging with Hatchling
- define `task-manager` entry point and Ruff formatting rules

## Testing
- `python -m py_compile task_manager.py`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6841bee22638832aaaf0bfe51b565c16